### PR TITLE
Ergonomics improvements for cw_ownable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cw-ownable"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/packages/ownable/Cargo.toml
+++ b/packages/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-ownable"
-version     = "0.2.0"
+version     = "0.3.0"
 description = "Utility for controlling ownership of CosmWasm smart contracts"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -190,8 +190,9 @@ where
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust
     /// use cw_utils::Expiration;
+    ///
     /// assert_eq!(
     ///     Ownership {
     ///         owner: Some("blue"),
@@ -203,7 +204,7 @@ where
     ///         Attribute::new("owner", "blue"),
     ///         Attribute::new("pending_owner", "none"),
     ///         Attribute::new("pending_expiry", "expiration: never")
-    ///     ]
+    ///     ],
     /// )
     /// ```
     pub fn into_attributes(self) -> Vec<Attribute> {
@@ -216,7 +217,7 @@ where
 }
 
 fn none_or<T: Display>(or: Option<&T>) -> String {
-    or.map(|or| format!("{}", or)).unwrap_or_else(|| "none".to_string())
+    or.map_or_else(|| "none".to_string(), |or| format!("{}", or))
 }
 
 /// Propose to transfer the contract's ownership to the given address, with an
@@ -324,7 +325,11 @@ mod tests {
     use super::*;
 
     fn mock_addresses() -> [Addr; 3] {
-        [Addr::unchecked("larry"), Addr::unchecked("jake"), Addr::unchecked("pumpkin")]
+        [
+            Addr::unchecked("larry"),
+            Addr::unchecked("jake"),
+            Addr::unchecked("pumpkin"),
+        ]
     }
 
     fn mock_block_at_height(height: u64) -> BlockInfo {

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
+use std::fmt::Display;
+
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, BlockInfo, DepsMut, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, Api, Attribute, BlockInfo, DepsMut, StdError, StdResult, Storage};
 use cw_storage_plus::Item;
 
 /// Append `cw-ownable`'s execute message variants to an enum.
@@ -39,7 +41,7 @@ use cw_storage_plus::Item;
 /// }
 /// ```
 ///
-/// Note, `#[cw_serde]` must be applied _before_ `#[cw_serde]`.
+/// Note, `#[cw_ownable]` must be applied _before_ `#[cw_serde]`.
 pub use cw_ownable_derive::cw_ownable;
 
 // re-export this struct which is used by the proc macro
@@ -113,18 +115,18 @@ pub enum OwnershipError {
 }
 
 /// Storage constant for the contract's ownership
-pub const OWNERSHIP: Item<Ownership<Addr>> = Item::new("ownership");
+const OWNERSHIP: Item<Ownership<Addr>> = Item::new("ownership");
 
 /// Set the given address as the contract owner.
 ///
 /// This function is only intended to be used only during contract instantiation.
-pub fn initialize_owner(deps: DepsMut, owner: &str) -> StdResult<()> {
+pub fn initialize_owner(storage: &mut dyn Storage, api: &dyn Api, owner: &str) -> StdResult<()> {
     let ownership = Ownership {
-        owner: Some(deps.api.addr_validate(owner)?),
+        owner: Some(api.addr_validate(owner)?),
         pending_owner: None,
         pending_expiry: None,
     };
-    OWNERSHIP.save(deps.storage, &ownership)
+    OWNERSHIP.save(storage, &ownership)
 }
 
 /// Assert that an account is the contract's current owner.
@@ -160,6 +162,61 @@ pub fn update_ownership(
         Action::AcceptOwnership => accept_ownership(deps.storage, block, sender),
         Action::RenounceOwnership => renounce_ownership(deps.storage, sender),
     }
+}
+
+/// Get the current ownership value.
+pub fn get_ownership(storage: &dyn Storage) -> StdResult<Ownership<Addr>> {
+    OWNERSHIP.load(storage)
+}
+
+impl<T> Ownership<T>
+where
+    T: Display,
+{
+    /// Serializes the current ownership state as attributes which may
+    /// be used in a message response. Serialization is done according
+    /// to the std::fmt::Display implementation for `T` and
+    /// `cosmwasm_std::Expiration` (for `pending_expiry`). If an
+    /// ownership field has no value, `"none"` will be serialized.
+    ///
+    /// Attribute keys used:
+    ///  - owner
+    ///  - pending_owner
+    ///  - pending_expiry
+    ///
+    /// Callers should take care not to use these keys elsewhere
+    /// in their response as CosmWasm will override reused attribute
+    /// keys.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cw_utils::Expiration;
+    /// assert_eq!(
+    ///     Ownership {
+    ///         owner: Some("blue"),
+    ///         pending_owner: None,
+    ///         pending_expiry: Some(Expiration::Never {})
+    ///     }
+    ///     .into_attributes(),
+    ///     vec![
+    ///         Attribute::new("owner", "blue"),
+    ///         Attribute::new("pending_owner", "none"),
+    ///         Attribute::new("pending_expiry", "expiration: never")
+    ///     ]
+    /// )
+    /// ```
+    pub fn into_attributes(self) -> Vec<Attribute> {
+        vec![
+            Attribute::new("owner", none_or(self.owner.as_ref())),
+            Attribute::new("pending_owner", none_or(self.pending_owner.as_ref())),
+            Attribute::new("pending_expiry", none_or(self.pending_expiry.as_ref())),
+        ]
+    }
+}
+
+fn none_or<T: Display>(or: Option<&T>) -> String {
+    or.map(|or| format!("{}", or)).unwrap_or_else(|| "none".to_string())
 }
 
 /// Propose to transfer the contract's ownership to the given address, with an
@@ -267,11 +324,7 @@ mod tests {
     use super::*;
 
     fn mock_addresses() -> [Addr; 3] {
-        [
-            Addr::unchecked("larry"),
-            Addr::unchecked("jake"),
-            Addr::unchecked("pumpkin"),
-        ]
+        [Addr::unchecked("larry"), Addr::unchecked("jake"), Addr::unchecked("pumpkin")]
     }
 
     fn mock_block_at_height(height: u64) -> BlockInfo {
@@ -287,7 +340,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let [larry, _, _] = mock_addresses();
 
-        initialize_owner(deps.as_mut(), larry.as_str()).unwrap();
+        initialize_owner(&mut deps.storage, &deps.api, larry.as_str()).unwrap();
 
         let ownership = OWNERSHIP.load(deps.as_ref().storage).unwrap();
         assert_eq!(
@@ -307,7 +360,7 @@ mod tests {
 
         // case 1. owner has not renounced
         {
-            initialize_owner(deps.as_mut(), larry.as_str()).unwrap();
+            initialize_owner(&mut deps.storage, &deps.api, larry.as_str()).unwrap();
 
             let res = assert_owner(deps.as_ref().storage, &larry);
             assert!(res.is_ok());
@@ -330,7 +383,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let [larry, jake, pumpkin] = mock_addresses();
 
-        initialize_owner(deps.as_mut(), larry.as_str()).unwrap();
+        initialize_owner(&mut deps.storage, &deps.api, larry.as_str()).unwrap();
 
         // non-owner cannot transfer ownership
         {
@@ -378,7 +431,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let [larry, jake, pumpkin] = mock_addresses();
 
-        initialize_owner(deps.as_mut(), larry.as_str()).unwrap();
+        initialize_owner(&mut deps.storage, &deps.api, larry.as_str()).unwrap();
 
         // cannot accept ownership when there isn't a pending ownership transfer
         {
@@ -503,5 +556,23 @@ mod tests {
             .unwrap_err();
             assert_eq!(err, OwnershipError::NoOwner);
         }
+    }
+
+    #[test]
+    fn into_attributes_works() {
+        use cw_utils::Expiration;
+        assert_eq!(
+            Ownership {
+                owner: Some("blue"),
+                pending_owner: None,
+                pending_expiry: Some(Expiration::Never {})
+            }
+            .into_attributes(),
+            vec![
+                Attribute::new("owner", "blue"),
+                Attribute::new("pending_owner", "none"),
+                Attribute::new("pending_expiry", "expiration: never")
+            ]
+        )
     }
 }

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -577,7 +577,7 @@ mod tests {
                 Attribute::new("owner", "blue"),
                 Attribute::new("pending_owner", "none"),
                 Attribute::new("pending_expiry", "expiration: never")
-            ]
-        )
+            ],
+        );
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 match_block_trailing_comma = true
 max_width = 100
 use_small_heuristics = "off"
+format_code_in_doc_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
+format_code_in_doc_comments = true
 match_block_trailing_comma = true
 max_width = 100
 use_small_heuristics = "off"
-format_code_in_doc_comments = true


### PR DESCRIPTION
These are  some things I noticed trying to use this library in dao-contracts.

1. Make `OWNERSHIP` storage private.
2. Add `get_ownership` fn to retreive current ownership.
3. Take storage and API by reference in `initialize_owner`.
4. Add `into_attributes` method for converting ownership information into attributes that may be added to a response.

(3) removes the need to make deps mutable during instantiation. For example, before unless `initialize_owner` was the last user of `deps` (i.e. a move could be performed) it would need to be called like:

```rust
    cw_ownable::initialize_owner(deps.branch(), &msg.owner)?;
```

As `branch` requires a mutable reference to `deps`, `deps` would then need to be mutable in the instantiate method signature:

```rust
pub fn instantiate(
    mut deps: DepsMut,
    env: Env,
    info: MessageInfo,
    msg: InstantiateMsg,
) -> Result<Response, ContractError> {
  // ...
}
```

Now, storage and the api can be passed into the method:

```rust
    let mut deps = mock_dependencies();
    cw_ownable::initialize_owner(&mut deps.storage, &deps.api, &msg.owner).unwrap();
```

(4) removes the tedium of library consumers needing to come up with their own encoding standard for the `Ownership` type returned by `update_ownership`.