### PR TITLE
More ownable improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "cw-ownable"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "cw-ownable-derive"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ license    = "AGPL-3.0-or-later"
 keywords   = ["cosmos", "cosmwasm"]
 
 [workspace.dependencies]
-cosmwasm-schema = "1.1"
-cosmwasm-std    = "1.1"
-cw-storage-plus = "1.0"
-cw-utils        = "1.0"
-proc-macro2     = "1"
-quote           = "1"
-serde           = { version = "1", default-features = false }
-syn             = "1"
-thiserror       = "1"
+cosmwasm-schema   = "1.1"
+cosmwasm-std      = "1.1"
+cw-address-like   = { version = "1.0.3", path = "./packages/address-like" }
+cw-ownable-derive = { version = "0.4.0", path = "./packages/ownable/derive" }
+cw-storage-plus   = "1.0"
+cw-utils          = "1.0"
+proc-macro2       = "1"
+quote             = "1"
+serde             = { version = "1", default-features = false }
+syn               = "1"
+thiserror         = "1"

--- a/packages/ownable/Cargo.toml
+++ b/packages/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-ownable"
-version     = "0.3.0"
+version     = "0.4.0"
 description = "Utility for controlling ownership of CosmWasm smart contracts"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/ownable/Cargo.toml
+++ b/packages/ownable/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false # disable doc tests
 [dependencies]
 cosmwasm-schema   = { workspace = true }
 cosmwasm-std      = { workspace = true }
+cw-address-like   = { path = "../address-like" }
 cw-ownable-derive = { version = "0.2.0", path = "./derive" }
 cw-storage-plus   = { workspace = true }
 cw-utils          = { workspace = true }

--- a/packages/ownable/Cargo.toml
+++ b/packages/ownable/Cargo.toml
@@ -15,8 +15,8 @@ doctest = false # disable doc tests
 [dependencies]
 cosmwasm-schema   = { workspace = true }
 cosmwasm-std      = { workspace = true }
-cw-address-like   = { path = "../address-like" }
-cw-ownable-derive = { version = "0.2.0", path = "./derive" }
+cw-address-like   = { workspace = true }
+cw-ownable-derive = { workspace = true }
 cw-storage-plus   = { workspace = true }
 cw-utils          = { workspace = true }
 thiserror         = { workspace = true }

--- a/packages/ownable/derive/Cargo.toml
+++ b/packages/ownable/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-ownable-derive"
-version     = "0.2.0"
+version     = "0.4.0"
 description = "Macros for generating code used by the `cw-ownable` crate"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/ownable/derive/src/lib.rs
+++ b/packages/ownable/derive/src/lib.rs
@@ -45,15 +45,15 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
     quote! { #left }.into()
 }
 
-/// Append `cw-ownable`'s execute message variants to an enum.
+/// Append ownership-related execute message variant(s) to an enum.
 ///
-/// For example, apply the `cw_ownable` macro to the following enum:
+/// For example, apply the `cw_ownable_execute` macro to the following enum:
 ///
 /// ```rust
 /// use cosmwasm_schema::cw_serde;
-/// use cw_ownable::cw_ownable;
+/// use cw_ownable::cw_ownable_exeucte;
 ///
-/// #[cw_ownable]
+/// #[cw_ownable_execute]
 /// #[cw_serde]
 /// enum ExecuteMsg {
 ///     Foo {},
@@ -65,24 +65,19 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
 ///
 /// ```rust
 /// use cosmwasm_schema::cw_serde;
-/// use cw_utils::Expiration;
+/// use cw_ownable::Action;
 ///
 /// #[cw_serde]
 /// enum ExecuteMsg {
-///     TransferOwnership {
-///         new_owner: String,
-///         expiry: Option<Expiration>,
-///     },
-///     AcceptOwnership {},
-///     RenounceOwnership {},
+///     UpdateOwnership(Action),
 ///     Foo {},
 ///     Bar {},
 /// }
 /// ```
 ///
-/// Note, `#[cw_ownable]` must be applied _before_ `#[cw_serde]`.
+/// Note: `#[cw_ownable_execute]` must be applied _before_ `#[cw_serde]`.
 #[proc_macro_attribute]
-pub fn cw_ownable(metadata: TokenStream, input: TokenStream) -> TokenStream {
+pub fn cw_ownable_execute(metadata: TokenStream, input: TokenStream) -> TokenStream {
     merge_variants(
         metadata,
         input,
@@ -93,6 +88,59 @@ pub fn cw_ownable(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 /// accept a pending ownership transfer, or renounce the ownership
                 /// permanently.
                 UpdateOwnership(::cw_ownable::Action),
+            }
+        }
+        .into(),
+    )
+}
+
+/// Append ownership-related query message variant(s) to an enum.
+///
+/// For example, apply the `cw_ownable_query` macro to the following enum:
+///
+/// ```rust
+/// use cosmwasm_schema::{cw_serde, QueryResponses};
+/// use cw_ownable::cw_ownable_query;
+///
+/// #[cw_ownable_query]
+/// #[cw_serde]
+/// #[derive(QueryResponses)]
+/// enum QueryMsg {
+///     #[returns(FooResponse)]
+///     Foo {},
+///     #[returns(BarResponse)]
+///     Bar {},
+/// }
+/// ```
+///
+/// Is equivalent to:
+///
+/// ```rust
+/// use cosmwasm_schema::cw_serde;
+///
+/// #[cw_serde]
+/// #[derive(QueryResponses)]
+/// enum ExecuteMsg {
+///     #[returns(OwnershipResponse)]
+///     Ownership {},
+///     #[returns(FooResponse)]
+///     Foo {},
+///     #[returns(BarResponse)]
+///     Bar {},
+/// }
+/// ```
+///
+/// Note: `#[cw_ownable_query]` must be applied _before_ `#[cw_serde]`.
+#[proc_macro_attribute]
+pub fn cw_ownable_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    merge_variants(
+        metadata,
+        input,
+        quote! {
+            enum Right {
+                /// Query the contract's ownership information
+                #[returns(::cw_ownable::Ownership<String>)]
+                Ownership {},
             }
         }
         .into(),

--- a/packages/ownable/derive/src/lib.rs
+++ b/packages/ownable/derive/src/lib.rs
@@ -117,11 +117,12 @@ pub fn cw_ownable_execute(metadata: TokenStream, input: TokenStream) -> TokenStr
 ///
 /// ```rust
 /// use cosmwasm_schema::cw_serde;
+/// use cw_ownable::Ownership;
 ///
 /// #[cw_serde]
 /// #[derive(QueryResponses)]
 /// enum ExecuteMsg {
-///     #[returns(OwnershipResponse)]
+///     #[returns(Ownership<String>)]
 ///     Ownership {},
 ///     #[returns(FooResponse)]
 ///     Foo {},

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -4,13 +4,16 @@ use std::fmt::Display;
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api, Attribute, BlockInfo, DepsMut, StdError, StdResult, Storage};
-pub use cw_ownable_derive::cw_ownable;
+use cw_address_like::AddressLike;
 use cw_storage_plus::Item;
+
+// re-export the proc macros and the Expiration class
+pub use cw_ownable_derive::{cw_ownable_execute, cw_ownable_query};
 pub use cw_utils::Expiration;
 
 /// The contract's ownership info
 #[cw_serde]
-pub struct Ownership<T> {
+pub struct Ownership<T: AddressLike> {
     /// The contract's current owner.
     /// `None` if the ownership has been renounced.
     pub owner: Option<T>,
@@ -134,10 +137,7 @@ pub fn get_ownership(storage: &dyn Storage) -> StdResult<Ownership<Addr>> {
     OWNERSHIP.load(storage)
 }
 
-impl<T> Ownership<T>
-where
-    T: Display,
-{
+impl<T: AddressLike> Ownership<T> {
     /// Serializes the current ownership state as attributes which may
     /// be used in a message response. Serialization is done according
     /// to the std::fmt::Display implementation for `T` and
@@ -279,9 +279,9 @@ fn renounce_ownership(
     })
 }
 
-//--------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Tests
-//--------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -290,7 +290,11 @@ mod tests {
     use super::*;
 
     fn mock_addresses() -> [Addr; 3] {
-        [Addr::unchecked("larry"), Addr::unchecked("jake"), Addr::unchecked("pumpkin")]
+        [
+            Addr::unchecked("larry"),
+            Addr::unchecked("jake"),
+            Addr::unchecked("pumpkin"),
+        ]
     }
 
     fn mock_block_at_height(height: u64) -> BlockInfo {
@@ -544,7 +548,7 @@ mod tests {
         use cw_utils::Expiration;
         assert_eq!(
             Ownership {
-                owner: Some("blue"),
+                owner: Some("blue".to_string()),
                 pending_owner: None,
                 pending_expiry: Some(Expiration::Never {})
             }

--- a/packages/ownable/tests/macro.rs
+++ b/packages/ownable/tests/macro.rs
@@ -1,9 +1,9 @@
-use cosmwasm_schema::cw_serde;
-use cw_ownable::{cw_ownable, Action};
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cw_ownable::{cw_ownable_execute, cw_ownable_query, Action};
 
-#[cw_ownable]
+#[cw_ownable_execute]
 #[cw_serde]
-enum MyEnum {
+enum ExecuteMsg {
     Foo,
     Bar(u64),
     Fuzz {
@@ -11,21 +11,52 @@ enum MyEnum {
     },
 }
 
+#[cw_ownable_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+enum QueryMsg {
+    #[returns(String)]
+    Foo,
+
+    #[returns(String)]
+    Bar(u64),
+
+    #[returns(String)]
+    Fuzz {
+        buzz: String,
+    },
+}
+
 #[test]
 fn derive_execute_variants() {
-    let my_enum = MyEnum::Foo;
+    let msg = ExecuteMsg::Foo;
 
     // If this compiles we have won.
-    match my_enum {
-        MyEnum::UpdateOwnership(Action::TransferOwnership {
+    match msg {
+        ExecuteMsg::UpdateOwnership(Action::TransferOwnership {
             new_owner: _,
             expiry: _,
         })
-        | MyEnum::UpdateOwnership(Action::AcceptOwnership)
-        | MyEnum::UpdateOwnership(Action::RenounceOwnership)
-        | MyEnum::Foo
-        | MyEnum::Bar(_)
-        | MyEnum::Fuzz {
+        | ExecuteMsg::UpdateOwnership(Action::AcceptOwnership)
+        | ExecuteMsg::UpdateOwnership(Action::RenounceOwnership)
+        | ExecuteMsg::Foo
+        | ExecuteMsg::Bar(_)
+        | ExecuteMsg::Fuzz {
+            ..
+        } => "yay",
+    };
+}
+
+#[test]
+fn derive_query_variants() {
+    let msg = QueryMsg::Foo;
+
+    // If this compiles we have won.
+    match msg {
+        QueryMsg::Ownership {}
+        | QueryMsg::Foo
+        | QueryMsg::Bar(_)
+        | QueryMsg::Fuzz {
             ..
         } => "yay",
     };


### PR DESCRIPTION
Closes: #3 
Closes: #6 

- Rename `#[cw_ownable]` macro to `#[cw_ownable_execute]`
- Add a `#[cw_ownable_query]` macro to create a query message variant: `#[returns(Ownership<String>)] Ownership {}`
- Use `AddressLike` trait to enforce that the generic `T` in `Ownership<T>` can only be either `String` or `Addr` 
