### PR TITLE
Remove unstable let-else statements from cw-ownable-derive.

### DIFF
--- a/packages/ownable/derive/src/lib.rs
+++ b/packages/ownable/derive/src/lib.rs
@@ -19,24 +19,30 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
 
     // parse the left enum
     let mut left: DeriveInput = parse_macro_input!(left);
-    let Enum(DataEnum {
-        variants,
-        ..
-    }) = &mut left.data else {
-        return syn::Error::new(left.ident.span(), "only enums can accept variants")
-            .to_compile_error()
-            .into();
+    let variants = match &mut left.data {
+        Enum(DataEnum {
+            variants,
+            ..
+        }) => variants,
+        _ => {
+            return syn::Error::new(left.ident.span(), "only enums can accept variants")
+                .to_compile_error()
+                .into()
+        },
     };
 
-    // parse the right enum
     let right: DeriveInput = parse_macro_input!(right);
-    let Enum(DataEnum {
-        variants: to_add,
-        ..
-    }) = right.data else {
-        return syn::Error::new(left.ident.span(), "only enums can provide variants")
-            .to_compile_error()
-            .into();
+    // parse the right enum
+    let to_add = match right.data {
+        Enum(DataEnum {
+            variants,
+            ..
+        }) => variants,
+        _ => {
+            return syn::Error::new(left.ident.span(), "only enums can provide variants")
+                .to_compile_error()
+                .into()
+        },
     };
 
     // insert variants from the right to the left

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -106,7 +106,7 @@ pub fn is_owner(store: &dyn Storage, addr: &Addr) -> StdResult<bool> {
 
     if let Some(owner) = ownership.owner {
         if *addr == owner {
-            return Ok(true)
+            return Ok(true);
         }
     }
 
@@ -198,7 +198,7 @@ impl<T: AddressLike> Ownership<T> {
 }
 
 fn none_or<T: Display>(or: Option<&T>) -> String {
-    or.map_or_else(|| "none".to_string(), |or| format!("{}", or))
+    or.map_or_else(|| "none".to_string(), |or| format!("{or}"))
 }
 
 /// Propose to transfer the contract's ownership to the given address, with an
@@ -306,11 +306,7 @@ mod tests {
     use super::*;
 
     fn mock_addresses() -> [Addr; 3] {
-        [
-            Addr::unchecked("larry"),
-            Addr::unchecked("jake"),
-            Addr::unchecked("pumpkin"),
-        ]
+        [Addr::unchecked("larry"), Addr::unchecked("jake"), Addr::unchecked("pumpkin")]
     }
 
     fn mock_block_at_height(height: u64) -> BlockInfo {


### PR DESCRIPTION
resolves #10 

this will let this crate be used in workspaces that use stable rust.