### PR TITLE
Fix typo in README.md: unimplemneted!() -> unimplemented!()

### DIFF
--- a/packages/ownable/README.md
+++ b/packages/ownable/README.md
@@ -70,7 +70,7 @@ pub fn execute(
         ExecuteMsg::UpdateOwnership(action) => {
             update_ownership(deps, &env.block, &info.sender, action)?;
         }
-        _ => unimplemneted!(),
+        _ => unimplemented!(),
     }
     Ok(Response::new())
 }


### PR DESCRIPTION
There was a minor typo in docs, unimplemented was misspelled so I wanted to correct it.