### PR TITLE
Bump CosmWasm to v2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,21 +15,27 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "block-buffer"
@@ -48,6 +54,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bnum"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "byteorder"
@@ -69,9 +81,9 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.7"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb64554a91d6a9231127f4355d351130a0b94e663d5d9dc8b3a54ca17d83de49"
+checksum = "6bf91c32ff87ffec3f1a36d03c96a528bc7447b9774c0616e5b092d7a3fd6503"
 dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
@@ -82,18 +94,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.7"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0fb2ce09f41a3dae1a234d56a9988f9aff4c76441cd50ef1ee9a4f20415b028"
+checksum = "9125094db6fdf355525d0968d5a2b3a23f82dfc9553efd64942a545ac086eed8"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.2.7"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230e5d1cefae5331db8934763c81b9c871db6a2cd899056a5694fa71d292c815"
+checksum = "d403dea1175a5b20fd2d29dda180fa9f1391dd46f354a8639391d1e549a99e5e"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -104,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.2.7"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43dadf7c23406cb28079d69e6cb922c9c29b9157b0fe887e3b79c783b7d4bcb8"
+checksum = "e3c3153038e91080ded2e2554689e802be2a34a24c6e49c039ae94810c99a680"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -115,11 +127,13 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.7"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4337eef8dfaf8572fe6b6b415d6ec25f9308c7bb09f2da63789209fb131363be"
+checksum = "eae364adb252732194283cd06dea3de2a1ed1e97d5033cdfd0fb651daa5a0100"
 dependencies = [
  "base64",
+ "bech32",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
@@ -129,8 +143,8 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.7",
+ "static_assertions",
  "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -143,16 +157,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -185,14 +193,14 @@ dependencies = [
 
 [[package]]
 name = "cw-address-like"
-version = "1.0.4"
+version = "2.0.4"
 dependencies = [
  "cosmwasm-std",
 ]
 
 [[package]]
 name = "cw-item-set"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -200,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "cw-optional-indexes"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -209,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "cw-ownable"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -222,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cw-ownable-derive"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -231,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -240,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0e92a069d62067f3472c62e30adedb4cab1754725c0f2a682b3128d2bf3c79"
+checksum = "f13360e9007f51998d42b1bc6b7fa0141f74feae61ed5fd1e5b0a89eec7b5de1"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -251,28 +259,12 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
+checksum = "07dfee7f12f802431a856984a32bce1cb7da1e6c006b5409e3981035ce562dec"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2",
- "schemars",
- "semver",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw2"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ac2dc7a55ad64173ca1e0a46697c31b7a5c51342f55a1e84a724da4eb99908"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
  "schemars",
  "serde",
  "thiserror",
@@ -280,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -315,6 +307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -327,14 +320,16 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -354,13 +349,12 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
  "digest 0.10.7",
  "ff",
  "generic-array",
@@ -374,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -396,6 +390,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -411,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -452,14 +447,16 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.7",
+ "signature",
 ]
 
 [[package]]
@@ -470,9 +467,9 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -482,9 +479,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -492,18 +489,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -525,13 +522,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -542,9 +538,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "fc6e7ed6919cb46507fb01ff1654309219f62b4d603822501b0b80d42f6f21ef"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -554,21 +550,21 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "185f2b7aa7e02d418e453790dde16890256bbd2bcd04b7dc5348811052b53f49"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.62",
 ]
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -579,49 +575,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+checksum = "f05da0d153dd4595bdffd5099dc0e9ce425b205ee648eb93437ff7302af8c9a5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.62",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.62",
 ]
 
 [[package]]
@@ -661,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -671,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -704,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "9f660c3bfcefb88c538776b6685a0c472e3128b51e74d48793dc2a488196e8eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -715,22 +705,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.62",
 ]
 
 [[package]]
@@ -738,18 +728,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unicode-ident"
@@ -771,6 +749,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords   = ["cosmos", "cosmwasm"]
 [workspace.dependencies]
 cosmwasm-schema   = "2.0"
 cosmwasm-std      = "2.0"
-cw-address-like   = { version = "1.0.4", path = "./packages/address-like" }
-cw-ownable-derive = { version = "0.5.1", path = "./packages/ownable/derive" }
+cw-address-like   = { version = "2.0.0", path = "./packages/address-like" }
+cw-ownable-derive = { version = "0.6.0", path = "./packages/ownable/derive" }
 cw-storage-plus   = "2.0"
 cw-utils          = "2.0"
 proc-macro2       = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ license    = "Apache-2.0"
 keywords   = ["cosmos", "cosmwasm"]
 
 [workspace.dependencies]
-cosmwasm-schema   = "1.2"
-cosmwasm-std      = "1.2"
+cosmwasm-schema   = "2.0"
+cosmwasm-std      = "2.0"
 cw-address-like   = { version = "1.0.4", path = "./packages/address-like" }
 cw-ownable-derive = { version = "0.5.1", path = "./packages/ownable/derive" }
-cw-storage-plus   = "1.1"
-cw-utils          = "1.0"
+cw-storage-plus   = "2.0"
+cw-utils          = "2.0"
 proc-macro2       = "1"
 quote             = "1"
 serde             = { version = "1", default-features = false }

--- a/packages/address-like/Cargo.toml
+++ b/packages/address-like/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-address-like"
-version     = "1.0.4"
+version     = "2.0.4"
 description = "A trait that marks unchecked or checked CosmWasm address strings"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/item-set/Cargo.toml
+++ b/packages/item-set/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-item-set"
-version     = "0.7.1"
+version     = "0.8.0"
 description = "Set of non-duplicate items for smart contract store"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/item-set/src/lib.rs
+++ b/packages/item-set/src/lib.rs
@@ -21,7 +21,7 @@ pub struct Set<'a, T> {
     namespace: &'a [u8],
 
     #[cfg(feature = "counter")]
-    counter: Item<'a, u64>,
+    counter: Item<u64>,
 
     item_type: PhantomData<T>,
 }
@@ -40,7 +40,7 @@ impl<'a, T> Set<'a, T> {
 #[cfg(feature = "counter")]
 impl<'a, T> Set<'a, T> {
     /// Create a new instance of the item set with the given map and counter namespaces.
-    pub const fn new(namespace: &'a str, counter_namespace: &'a str) -> Self {
+    pub const fn new(namespace: &'a str, counter_namespace: &'static str) -> Self {
         Set {
             namespace: namespace.as_bytes(),
             counter: Item::new(counter_namespace),

--- a/packages/optional-indexes/Cargo.toml
+++ b/packages/optional-indexes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-optional-indexes"
-version     = "0.1.1"
+version     = "0.2.0"
 description = "Index types for CosmWasm IndexedMaps where an item may or may not have an index"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/optional-indexes/src/unique.rs
+++ b/packages/optional-indexes/src/unique.rs
@@ -16,14 +16,14 @@ pub(crate) struct UniqueRef<T> {
 /// In cw-sdk, this is used in the `ACCOUNTS` map, where smart contract accounts
 /// are indexed by their labels such that we can enforce that the labels are
 /// unique, while base accounts are not indexed.
-pub struct OptionalUniqueIndex<'a, IK, T, PK = ()> {
+pub struct OptionalUniqueIndex<IK, T, PK = ()> {
     index: fn(&T) -> Option<IK>,
-    idx_map: Map<'a, IK, UniqueRef<T>>,
+    idx_map: Map<IK, UniqueRef<T>>,
     phantom: PhantomData<PK>,
 }
 
-impl<'a, IK, T, PK> OptionalUniqueIndex<'a, IK, T, PK> {
-    pub const fn new(idx_fn: fn(&T) -> Option<IK>, idx_namespace: &'a str) -> Self {
+impl<'a, IK, T, PK> OptionalUniqueIndex<IK, T, PK> {
+    pub const fn new(idx_fn: fn(&T) -> Option<IK>, idx_namespace: &'static str) -> Self {
         Self {
             index: idx_fn,
             idx_map: Map::new(idx_namespace),
@@ -32,7 +32,7 @@ impl<'a, IK, T, PK> OptionalUniqueIndex<'a, IK, T, PK> {
     }
 }
 
-impl<'a, IK, T, PK> OptionalUniqueIndex<'a, IK, T, PK>
+impl<'a, IK, T, PK> OptionalUniqueIndex<IK, T, PK>
 where
     PK: KeyDeserialize,
     IK: PrimaryKey<'a>,
@@ -41,7 +41,7 @@ where
     pub fn load(&self, store: &dyn Storage, key: IK) -> StdResult<(PK::Output, T)> {
         let UniqueRef {
             pk,
-            value
+            value,
         } = self.idx_map.load(store, key)?;
         let key = PK::from_slice(&pk)?;
         Ok((key, value))
@@ -82,13 +82,13 @@ where
     }
 }
 
-impl<'a, IK, T, PK> Index<T> for OptionalUniqueIndex<'a, IK, T, PK>
+impl<'a, IK, T, PK> Index<T> for OptionalUniqueIndex<IK, T, PK>
 where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a>,
 {
     fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()> {
-        // only save data in idx_map if the index in `Some`
+        // only save data in idx_map if the index is `Some`
         if let Some(idx) = (self.index)(data) {
             self.idx_map.update(store, idx, |opt| {
                 if opt.is_some() {

--- a/packages/ownable/Cargo.toml
+++ b/packages/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-ownable"
-version     = "0.5.1"
+version     = "0.6.0"
 description = "Utility for controlling ownership of CosmWasm smart contracts"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/ownable/derive/Cargo.toml
+++ b/packages/ownable/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-ownable-derive"
-version     = "0.5.1"
+version     = "0.6.0"
 description = "Macros for generating code used by the `cw-ownable` crate"
 authors     = { workspace = true }
 edition     = { workspace = true }

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -291,15 +291,15 @@ fn renounce_ownership(
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{testing::mock_dependencies, Timestamp};
+    use cosmwasm_std::{testing::{mock_dependencies, MockApi}, Timestamp};
 
     use super::*;
 
-    fn mock_addresses() -> [Addr; 3] {
+    fn mock_addresses(api: &MockApi) -> [Addr; 3] {
         [
-            Addr::unchecked("larry"),
-            Addr::unchecked("jake"),
-            Addr::unchecked("pumpkin"),
+            api.addr_make("larry"),
+            api.addr_make("jake"),
+            api.addr_make("pumpkin"),
         ]
     }
 
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn initializing_ownership() {
         let mut deps = mock_dependencies();
-        let [larry, _, _] = mock_addresses();
+        let [larry, _, _] = mock_addresses(&deps.api);
 
         let ownership =
             initialize_owner(&mut deps.storage, &deps.api, Some(larry.as_str())).unwrap();
@@ -349,7 +349,7 @@ mod tests {
     #[test]
     fn asserting_ownership() {
         let mut deps = mock_dependencies();
-        let [larry, jake, _] = mock_addresses();
+        let [larry, jake, _] = mock_addresses(&deps.api);
 
         // case 1. owner has not renounced
         {
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn transferring_ownership() {
         let mut deps = mock_dependencies();
-        let [larry, jake, pumpkin] = mock_addresses();
+        let [larry, jake, pumpkin] = mock_addresses(&deps.api);
 
         initialize_owner(&mut deps.storage, &deps.api, Some(larry.as_str())).unwrap();
 
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn accepting_ownership() {
         let mut deps = mock_dependencies();
-        let [larry, jake, pumpkin] = mock_addresses();
+        let [larry, jake, pumpkin] = mock_addresses(&deps.api);
 
         initialize_owner(&mut deps.storage, &deps.api, Some(larry.as_str())).unwrap();
 
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn renouncing_ownership() {
         let mut deps = mock_dependencies();
-        let [larry, jake, pumpkin] = mock_addresses();
+        let [larry, jake, pumpkin] = mock_addresses(&deps.api);
 
         let ownership = Ownership {
             owner: Some(larry.clone()),

--- a/packages/paginate/Cargo.toml
+++ b/packages/paginate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cw-paginate"
-version     = "0.2.1"
+version     = "0.3.0"
 description = "Helper function for iterating CosmWasm storage maps with pagination"
 authors     = [
   "Larry Engineer <gm@larry.engineer>",

--- a/packages/paginate/src/lib.rs
+++ b/packages/paginate/src/lib.rs
@@ -31,7 +31,7 @@ where
 ///
 /// TODO: add docs
 pub fn paginate_map<'a, K, T, R, E, F>(
-    map: &Map<'a, K, T>,
+    map: &Map<K, T>,
     store: &dyn Storage,
     start: Option<Bound<'a, K>>,
     limit: Option<u32>,
@@ -52,7 +52,7 @@ where
 ///
 /// TODO: add docs
 pub fn paginate_map_prefix<'a, K, T, R, E, F>(
-    map: &Map<'a, K, T>,
+    map: &Map<K, T>,
     store: &dyn Storage,
     prefix: K::Prefix,
     start: Option<Bound<'a, K::Suffix>>,
@@ -75,7 +75,7 @@ where
 ///
 /// TODO: add docs
 pub fn paginate_indexed_map<'a, K, T, I, R, E, F>(
-    map: &IndexedMap<'a, K, T, I>,
+    map: &IndexedMap<K, T, I>,
     store: &dyn Storage,
     start: Option<Bound<'a, K>>,
     limit: Option<u32>,


### PR DESCRIPTION
Bumps CosmWasm deps to `v2.0` and bumps package versions.

Getting these packages updated is a requirement for many projects to upgrade. 