### PR TITLE
add multi-owner `cw-ownable` with cosmwasm v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of [CosmWasm][1] utilities and helper libraries.
 | [cw-address-like][2]     | v1.0.4  | A trait that marks unchecked or checked address strings                 |
 | [cw-item-set][3]         | v0.7.1  | Set of non-duplicate items for storage                                  |
 | [cw-optional-indexes][4] | v0.1.1  | Index types for `IndexedMap` where an item may or may not have an index |
-| [cw-ownable][5]          | v0.5.1  | Utility for controlling contract ownership                              |
+| [cw-ownable][5]          | v0.6.0  | Utility for controlling contract ownership                              |
 | [cw-paginate][6]         | v0.2.1  | Helper function for interating maps                                     |
 
 ## License

--- a/packages/optional-indexes/src/unique.rs
+++ b/packages/optional-indexes/src/unique.rs
@@ -22,7 +22,7 @@ pub struct OptionalUniqueIndex<IK, T, PK = ()> {
     phantom: PhantomData<PK>,
 }
 
-impl<'a, IK, T, PK> OptionalUniqueIndex<IK, T, PK> {
+impl<IK, T, PK> OptionalUniqueIndex<IK, T, PK> {
     pub const fn new(idx_fn: fn(&T) -> Option<IK>, idx_namespace: &'static str) -> Self {
         Self {
             index: idx_fn,

--- a/packages/ownable/README.md
+++ b/packages/ownable/README.md
@@ -123,6 +123,16 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 ```
 
+You can use ownership for other purposes:
+
+```rust
+use cw_ownable::OwnershipStore;
+
+pub const CREATOR: OwnershipStore = OwnershipStore::new("creator");
+```
+
+`CREATOR` has all functions in place: `initialize_owner`, `is_owner`, `assert_owner`, and `get_ownership`.
+
 ## License
 
 Contents of this crate at or prior to version `0.5.0` are published under [GNU Affero General Public License v3](https://github.com/steak-enjoyers/cw-plus-plus/blob/9c8fcf1c95b74dd415caf5602068c558e9d16ecc/LICENSE) or later; contents after the said version are published under [Apache-2.0](../../LICENSE) license.

--- a/packages/ownable/derive/src/lib.rs
+++ b/packages/ownable/derive/src/lib.rs
@@ -22,7 +22,8 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
     let Enum(DataEnum {
         variants,
         ..
-    }) = &mut left.data else {
+    }) = &mut left.data
+    else {
         return syn::Error::new(left.ident.span(), "only enums can accept variants")
             .to_compile_error()
             .into();
@@ -33,7 +34,8 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
     let Enum(DataEnum {
         variants: to_add,
         ..
-    }) = right.data else {
+    }) = right.data
+    else {
         return syn::Error::new(left.ident.span(), "only enums can provide variants")
             .to_compile_error()
             .into();

--- a/packages/ownable/derive/src/lib.rs
+++ b/packages/ownable/derive/src/lib.rs
@@ -40,7 +40,7 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
     };
 
     // insert variants from the right to the left
-    variants.extend(to_add.into_iter());
+    variants.extend(to_add);
 
     quote! { #left }.into()
 }

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -443,31 +443,33 @@ mod tests {
 
         // non-owner cannot transfer ownership
         {
-            let err = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(12345),
-                &jake,
-                Action::TransferOwnership {
-                    new_owner: pumpkin.to_string(),
-                    expiry: None,
-                },
-            )
-            .unwrap_err();
+            let err = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(12345),
+                    &jake,
+                    Action::TransferOwnership {
+                        new_owner: pumpkin.to_string(),
+                        expiry: None,
+                    },
+                )
+                .unwrap_err();
             assert_eq!(err, OwnershipError::NotOwner);
         }
 
         // owner properly transfers ownership
         {
-            let ownership = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(12345),
-                &larry,
-                Action::TransferOwnership {
-                    new_owner: pumpkin.to_string(),
-                    expiry: Some(Expiration::AtHeight(42069)),
-                },
-            )
-            .unwrap();
+            let ownership = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(12345),
+                    &larry,
+                    Action::TransferOwnership {
+                        new_owner: pumpkin.to_string(),
+                        expiry: Some(Expiration::AtHeight(42069)),
+                    },
+                )
+                .unwrap();
             assert_eq!(
                 ownership,
                 Ownership {
@@ -491,57 +493,62 @@ mod tests {
 
         // cannot accept ownership when there isn't a pending ownership transfer
         {
-            let err = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(12345),
-                &pumpkin,
-                Action::AcceptOwnership,
-            )
-            .unwrap_err();
+            let err = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(12345),
+                    &pumpkin,
+                    Action::AcceptOwnership,
+                )
+                .unwrap_err();
             assert_eq!(err, OwnershipError::TransferNotFound);
         }
 
-        OWNERSHIP.transfer_ownership(
-            deps.as_mut(),
-            &larry,
-            pumpkin.as_str(),
-            Some(Expiration::AtHeight(42069)),
-        )
-        .unwrap();
+        OWNERSHIP
+            .transfer_ownership(
+                deps.as_mut(),
+                &larry,
+                pumpkin.as_str(),
+                Some(Expiration::AtHeight(42069)),
+            )
+            .unwrap();
 
         // non-pending owner cannot accept ownership
         {
-            let err = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(12345),
-                &jake,
-                Action::AcceptOwnership,
-            )
-            .unwrap_err();
+            let err = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(12345),
+                    &jake,
+                    Action::AcceptOwnership,
+                )
+                .unwrap_err();
             assert_eq!(err, OwnershipError::NotPendingOwner);
         }
 
         // cannot accept ownership if deadline has passed
         {
-            let err = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(69420),
-                &pumpkin,
-                Action::AcceptOwnership,
-            )
-            .unwrap_err();
+            let err = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(69420),
+                    &pumpkin,
+                    Action::AcceptOwnership,
+                )
+                .unwrap_err();
             assert_eq!(err, OwnershipError::TransferExpired);
         }
 
         // pending owner properly accepts ownership before deadline
         {
-            let ownership = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(10000),
-                &pumpkin,
-                Action::AcceptOwnership,
-            )
-            .unwrap();
+            let ownership = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(10000),
+                    &pumpkin,
+                    Action::AcceptOwnership,
+                )
+                .unwrap();
             assert_eq!(
                 ownership,
                 Ownership {
@@ -570,25 +577,27 @@ mod tests {
 
         // non-owner cannot renounce
         {
-            let err = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(12345),
-                &jake,
-                Action::RenounceOwnership,
-            )
-            .unwrap_err();
+            let err = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(12345),
+                    &jake,
+                    Action::RenounceOwnership,
+                )
+                .unwrap_err();
             assert_eq!(err, OwnershipError::NotOwner);
         }
 
         // owner properly renounces
         {
-            let ownership = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(12345),
-                &larry,
-                Action::RenounceOwnership,
-            )
-            .unwrap();
+            let ownership = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(12345),
+                    &larry,
+                    Action::RenounceOwnership,
+                )
+                .unwrap();
 
             // ownership returned is same as ownership stored.
             assert_eq!(ownership, OWNERSHIP.item.load(deps.as_ref().storage).unwrap());
@@ -605,13 +614,14 @@ mod tests {
 
         // cannot renounce twice
         {
-            let err = OWNERSHIP.update_ownership(
-                deps.as_mut(),
-                &mock_block_at_height(12345),
-                &larry,
-                Action::RenounceOwnership,
-            )
-            .unwrap_err();
+            let err = OWNERSHIP
+                .update_ownership(
+                    deps.as_mut(),
+                    &mock_block_at_height(12345),
+                    &larry,
+                    Action::RenounceOwnership,
+                )
+                .unwrap_err();
             assert_eq!(err, OwnershipError::NoOwner);
         }
     }

--- a/packages/ownable/src/lib.rs
+++ b/packages/ownable/src/lib.rs
@@ -28,12 +28,12 @@ pub struct Ownership<T: AddressLike> {
     pub pending_expiry: Option<Expiration>,
 }
 
-pub struct OwnershipStore<'a> {
-    pub item: Item<'a, Ownership<Addr>>,
+pub struct OwnershipStore {
+    pub item: Item<Ownership<Addr>>,
 }
 
-impl<'a> OwnershipStore<'a> {
-    pub const fn new(key: &'a str) -> Self {
+impl OwnershipStore {
+    pub const fn new(key: &'static str) -> Self {
         Self {
             item: Item::new(key),
         }


### PR DESCRIPTION
Includes work by @taitruong from #21
- Multiple-ownership `cw-ownable` (public-awesome#1)
- Rebased on current CosmWasm v2 updates (#23)
- Resolved merge conflicts
- Updated `cw-ownable` for CosmWasm v2 compatibility

Unblocks public-awesome/cw-nfts#160 and indirectly DA0-DA0/dao-contracts#840